### PR TITLE
Add Temperatures

### DIFF
--- a/lib/definitions/temperature.js
+++ b/lib/definitions/temperature.js
@@ -1,0 +1,44 @@
+var metric
+  , imperial;
+
+metric = {
+  C: {
+    name: {
+      singular: 'Celsius'
+    , plural: 'Celsius'
+    }
+  , to_anchor: 1
+  },
+  K: {
+    name: {
+      singular: 'Kelvin'
+    , plural: 'kelvin'
+    }
+  , to_anchor: 1+273.15
+  }
+};
+
+imperial = {
+  F: {
+    name: {
+      signular: 'Fahrenheit'
+    , plural: 'Fahrenheit'
+    }
+  , to_anchor: 1
+  }
+};
+
+module.exports = {
+  metric: metric
+, imperial: imperial
+, _anchors: {
+    metric: {
+      unit: 'C'
+    , ratio: 1
+    }
+  , imperial: {
+      unit: 'F'
+    , ratio: (1.8*C)+32;
+    }
+  }
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,7 @@ Converter.prototype.to = function (to) {
   /**
   * Convert to another unit inside the destination system
   */
-  return result / this.destination.unit.to_anchor;  
+  return result / this.destination.unit.to_anchor;
 };
 
 /**

--- a/test/incompatibilities.js
+++ b/test/incompatibilities.js
@@ -44,4 +44,10 @@ tests['.to before .from throws'] = function () {
   });
 };
 
+tests['.to before .from throws'] = function () {
+  assert.throws(function () {
+    convert(4).to('C').from('fl-oz');
+  });
+};
+
 module.exports = tests;

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -20,6 +20,12 @@ tests['m possibilities'] = function () {
   assert.deepEqual(actual, expected);
 };
 
+tests['C possibilities'] = function () {
+  var actual = convert().from('C').possibilities()
+    , expected = [ 'C', 'F', 'K' ];
+  assert.deepEqual(actual, expected);
+};
+
 tests['each possibilities'] = function () {
   var actual = convert().possibilities('each')
     , expected = [ 'ea' ];
@@ -44,9 +50,15 @@ tests['length possibilities'] = function () {
   assert.deepEqual(actual, expected);
 };
 
+tests['temperature possibilities'] = function () {
+  var actual = convert().possibilities('temperature')
+    , expected = [ 'C', 'F', 'K' ];
+  assert.deepEqual(actual, expected);
+};
+
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
-    , expected = [ 'mm', 'cm', 'm', 'in', 'ft', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'ml', 'ltr', 'tsp', 'Tbs', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ea' ];
+    , expected = [ 'mm', 'cm', 'm', 'in', 'ft', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'ml', 'ltr', 'tsp', 'Tbs', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ea', 'C', 'F', 'K' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/temperatures.js
+++ b/test/temperatures.js
@@ -1,0 +1,33 @@
+var convert = require('../lib')
+  , assert = require('assert')
+  , tests = {}
+  , ACCURACY = 1/1000
+  , percentError = require('../lib/percentError');
+
+tests['C to C'] = function () {
+  assert.strictEqual( convert(100).from('C').to('C') , 100);
+};
+
+// When converting between systems, expect < 0.1% error
+tests['C to F'] = function () {
+  var expected = 212
+    , actual = convert(100).from('C').to('F');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected + ', Actual: ' + actual);
+};
+
+tests['C to K'] = function () {
+  var expected = 373.15
+    , actual = convert(100).from('C').to('K');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected + ', Actual: ' + actual);
+};
+
+tests['F to K'] = function () {
+  var expected = 273.15
+    , actual = convert(32).from('F').to('K');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected + ', Actual: ' + actual);
+};
+
+module.exports = tests;


### PR DESCRIPTION
@ben-ng could you please advise.

I see your code makes the assumption that translating between units is a constant ratio between units. Between Celsius and Fahrenheit it's not a ratio but an inequality. See [here](http://www.virtualnerd.com/pre-algebra/inequalities-multi-step-equations/formulas/using-formulas/convert-celsius-fahrenheit).