### PR TITLE
Add ability to convert time

### DIFF
--- a/lib/definitions/time.js
+++ b/lib/definitions/time.js
@@ -1,0 +1,71 @@
+var time
+
+time = {
+  ms: {
+    name: {
+      singular: 'Millisecond'
+    , plural: 'Milliseconds'
+    }
+  , to_anchor: 1/1000
+  }
+, s: {
+    name: {
+      singular: 'Second'
+    , plural: 'Seconds'
+    }
+  , to_anchor: 1
+  }
+, min: {
+    name: {
+      singular: 'Minute'
+    , plural: 'Minutes'
+    }
+  , to_anchor: 60
+  }
+, h: {
+    name: {
+      singular: 'Hour'
+    , plural: 'Hours'
+    }
+  , to_anchor: 60 * 60 
+  }
+, d: {
+    name: {
+      singular: 'Day'
+    , plural: 'Days'
+    }
+  , to_anchor: 60 * 60 * 24
+  }
+, week: {
+    name: {
+      singular: 'Week'
+    , plural: 'Weeks'
+    }
+  , to_anchor: 60 * 60 * 24 * 7
+  }
+, month: {
+    name: {
+      singular: 'Month'
+    , plural: 'Months'
+    }
+  , to_anchor: 60 * 60 * 24 * 7 * 4 
+  }
+, year: {
+    name: {
+      singular: 'Year'
+    , plural: 'Years'
+    }
+  , to_anchor: 60 * 60 * 24 * 365
+  }
+};
+
+
+module.exports = {
+  metric: time 
+, _anchors: {
+    metric: {
+      unit: 's'
+    , ratio: 1
+    }
+  }
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ var convert
     ,  mass: require('./definitions/mass')
     , volume: require('./definitions/volume')
     , each: require('./definitions/each')
+    , time: require('./definitions/time')
     }
   , Converter;
 

--- a/test/measures.js
+++ b/test/measures.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['measures'] = function () {
   var actual = convert().measures()
-    , expected = [ 'length', 'mass', 'volume', 'each' ];
+    , expected = [ 'length', 'mass', 'volume', 'each', 'time' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -44,9 +44,15 @@ tests['length possibilities'] = function () {
   assert.deepEqual(actual, expected);
 };
 
+tests['time possibilities'] = function () {
+  var actual = convert().possibilities('time')
+    , expected = ['ms', 's', 'min', 'h', 'd', 'week', 'month', 'year']
+  assert.deepEqual(actual, expected)
+};
+
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
-    , expected = [ 'mm', 'cm', 'm', 'in', 'ft', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'ml', 'ltr', 'tsp', 'Tbs', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ea' ];
+    , expected = [ 'mm', 'cm', 'm', 'in', 'ft', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'ml', 'ltr', 'tsp', 'Tbs', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ea', 'ms', 's', 'min', 'h','d', 'week', 'month', 'year' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/times.js
+++ b/test/times.js
@@ -1,0 +1,36 @@
+var convert = require('../lib')
+  , assert = require('assert')
+  , tests = {}
+  , ACCURACY = 1/1000
+  , percentError = require('../lib/percentError');
+
+
+tests['s to ms'] = function () {
+  assert.strictEqual( convert(1).from('s').to('ms') , 1000);
+};
+
+tests['s to m'] = function () {
+  assert.strictEqual( convert(60).from('s').to('min'), 1);
+}
+
+tests['s to s'] = function () {
+  assert.strictEqual( convert(1).from('s').to('s'), 1);
+}
+
+tests['s to h'] = function () {
+  assert.strictEqual( convert(3600).from('s').to('h'), 1);
+};
+
+tests['s to d'] = function () {
+  assert.strictEqual( convert(86400).from('s').to('d'), 1);
+};
+
+tests['d to week'] = function () {
+  assert.strictEqual( convert(7).from('d').to('week'), 1);
+}
+
+tests['w to year'] = function () {
+  assert.strictEqual( convert(52).from('week').to('year'), 1);
+};
+
+module.exports = tests;


### PR DESCRIPTION
Using a simplified definition of 4 weeks = 1 month rather than strict
calendar time. Could switch this to 1/12 of a year instead.

This would be super useful to have so I can use the same library when converting user inputs.