### PR TITLE
Add temperature conversion

### DIFF
--- a/lib/definitions/temperature.js
+++ b/lib/definitions/temperature.js
@@ -1,0 +1,47 @@
+var metric
+  , imperial;
+
+metric = {
+  C: {
+    name: {
+      singular: 'degree Celsius'
+    , plural: 'degrees Celsius'
+    }
+  , to_anchor: 1
+  , anchor_shift: 0
+  },
+  K: {
+    name: {
+      singular: 'degree Kelvin'
+    , plural: 'degrees Kelvin'
+    }
+  , to_anchor: 1
+  , anchor_shift: 273.15
+  }
+};
+
+imperial = {
+  F: {
+    name: {
+      singular: 'degree Fahrenheit'
+    , plural: 'degrees Fahrenheit'
+    }
+  , to_anchor: 1
+  }
+};
+
+module.exports = {
+  metric: metric
+, imperial: imperial
+, _anchors: {
+    metric: {
+      unit: 'C'
+    , transform: function (C) { return C / (5/9) + 32 }
+    }
+  , imperial: {
+      unit: 'F'
+    , transform: function (F) { return (F - 32) * (5/9) }
+    }
+  }
+};
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,9 +3,10 @@ var convert
   , each = require('lodash.foreach')
   , measures = {
       length: require('./definitions/length')
-    ,  mass: require('./definitions/mass')
+    , mass: require('./definitions/mass')
     , volume: require('./definitions/volume')
     , each: require('./definitions/each')
+    , temperature: require('./definitions/temperature')
     }
   , Converter;
 
@@ -41,7 +42,8 @@ Converter.prototype.to = function (to) {
 
   this.destination = this.getUnit(to);
 
-  var result;
+  var result
+    , transform;
 
   if(!this.destination) {
     this.throwUnsupportedUnitError(to);
@@ -59,9 +61,29 @@ Converter.prototype.to = function (to) {
   result = this.val * this.origin.unit.to_anchor;
 
   /**
-  * Convert from one system to another through the anchor ratio
+  * For some changes it's a simple shift (C to K)
+  * So we'll add it when convering into the unit
+  * and substract it when converting from the unit
+  */
+  if (this.destination.unit.anchor_shift) {
+    result += this.destination.unit.anchor_shift;
+  }
+
+  if (this.origin.unit.anchor_shift) {
+    result -= this.origin.unit.anchor_shift
+  }
+
+
+  /**
+  * Convert from one system to another through the anchor ratio. Some conversions
+  * aren't ratio based or require more than a simple shift. We can provide a custom
+  * transform here to provide the direct result
   */
   if(this.origin.system != this.destination.system) {
+    transform = measures[this.origin.measure]._anchors[this.origin.system].transform;
+    if (typeof transform === 'function') {
+      return result = transform(result)
+    } 
     result *= measures[this.origin.measure]._anchors[this.origin.system].ratio;
   }
 

--- a/test/measures.js
+++ b/test/measures.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['measures'] = function () {
   var actual = convert().measures()
-    , expected = [ 'length', 'mass', 'volume', 'each' ];
+    , expected = [ 'length', 'mass', 'volume', 'each', 'temperature' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -44,9 +44,15 @@ tests['length possibilities'] = function () {
   assert.deepEqual(actual, expected);
 };
 
+tests['temperature possibilities'] = function () {
+  var actual = convert().possibilities('temperature')
+    , expected = ['C', 'K', 'F'];
+  assert.deepEqual(actual, expected);
+}
+
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
-    , expected = [ 'mm', 'cm', 'm', 'in', 'ft', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'ml', 'ltr', 'tsp', 'Tbs', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ea' ];
+    , expected = [ 'mm', 'cm', 'm', 'in', 'ft', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'ml', 'ltr', 'tsp', 'Tbs', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ea', 'C', 'K', 'F' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/temperature.js
+++ b/test/temperature.js
@@ -1,0 +1,21 @@
+var convert = require('../lib')
+  , assert = require('assert')
+  , tests = {};
+
+tests['C to K'] = function () {
+  assert.strictEqual( convert(0).from('C').to('K'), 273.15);
+};
+
+tests['K to C'] = function () {
+  assert.strictEqual( convert(273.15).from('K').to('C'), 0);
+};
+
+tests['F to C'] = function () {
+  assert.strictEqual( convert(32).from('F').to('C'), 0);
+};
+
+tests['C to F'] = function () {
+  assert.strictEqual( convert(0).from('C').to('F'), 32);
+};
+
+module.exports = tests;


### PR DESCRIPTION
Adds the ability to define a custom transform and a unit shift
for a specific conversion when that conversion is not
expressable by a ratio. Also defines transforms from Kelvin and C to F

I know there is an existing PR for this, but the tests were failing.   Let me know if this is not the direction you're looking for and I can change it, but converting temperatures isn't as simple as a ratio, nor a shift and a ratio since the shift has to occur either before or after the ratio, depending on the direction and I feel like writing logic to determine this order or sequence is probably more complex than allowing for a custom transformation function.