### PR TITLE
Add support for cubic volume units

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -136,15 +136,22 @@ Supported Units
 
 ### Volume
 
+ * mm3
+ * cm3
  * ml
  * ltr
+ * m3
+ * km3
  * tsp
  * tbsp
+ * in3
  * fl-oz
  * cup
  * pnt
  * qt
  * gal
+ * ft3
+ * yd3
 
 
 

--- a/lib/definitions/volume.js
+++ b/lib/definitions/volume.js
@@ -2,7 +2,21 @@ var metric
   , imperial;
 
 metric = {
-  ml: {
+  mm3: {
+      name: {
+        singular: 'Cubic Millimeter'
+      , plural: 'Cubic Millimeters'
+      }
+    , to_anchor: 1/1000000
+  }
+, cm3: {
+    name: {
+      singular: 'Cubic Centimeter'
+    , plural: 'Cubic Centimeters'
+    }
+  , to_anchor: 1/1000
+  }
+, ml: {
     name: {
       singular: 'Millilitre'
     , plural: 'Millilitres'
@@ -15,6 +29,20 @@ metric = {
     , plural: 'Litres'
     }
   , to_anchor: 1
+  }
+, m3: {
+    name: {
+      singular: 'Cubic meter'
+    , plural: 'Cubic meters'
+    }
+  , to_anchor: 1000
+  }
+, km3: {
+    name: {
+      singular: 'Cubic kilometer'
+    , plural: 'Cubic kilometers'
+    }
+  , to_anchor: 1000000000000
   }
 };
 
@@ -32,6 +60,13 @@ imperial = {
     , plural: 'Tablespoons'
     }
   , to_anchor: 1/2
+  }
+, in3: {
+    name: {
+      singular: 'Cubic inch'
+    , plural: 'Cubic inches'
+    }
+  , to_anchor: 0.55411
   }
 , 'fl-oz': {
     name: {
@@ -67,6 +102,20 @@ imperial = {
     , plural: 'Gallons'
     }
   , to_anchor: 128
+  }
+, ft3: {
+    name: {
+      singular: 'Cubic foot'
+    , plural: 'Cubic feet'
+    }
+  , to_anchor: 957.506
+  }
+, yd3: {
+    name: {
+      singular: 'Cubic yard'
+    , plural: 'Cubic yards'
+    }
+  , to_anchor: 25852.7
   }
 };
 

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['ltr possibilities'] = function () {
   var actual = convert().from('ltr').possibilities()
-    , expected = [ 'ml', 'ltr', 'tsp', 'Tbs', 'fl-oz', 'cup', 'pnt', 'qt', 'gal' ];
+    , expected = [ 'mm3', 'cm3', 'ml', 'ltr', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
   assert.deepEqual(actual, expected);
 };
 
@@ -34,7 +34,7 @@ tests['mass possibilities'] = function () {
 
 tests['volume possibilities'] = function () {
   var actual = convert().possibilities('volume')
-    , expected = [ 'ml', 'ltr', 'tsp', 'Tbs', 'fl-oz', 'cup', 'pnt', 'qt', 'gal' ];
+    , expected = [ 'mm3', 'cm3', 'ml', 'ltr', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
   assert.deepEqual(actual, expected);
 };
 
@@ -64,7 +64,7 @@ tests['digital possibilities'] = function() {
 
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
-    , expected = [ 'mm', 'cm', 'm', 'km', 'in', 'ft', 'mi', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'ml', 'ltr', 'tsp', 'Tbs', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ea', 'C', 'K', 'F', 'ms', 's', 'min', 'h','d', 'week', 'month', 'year', 'b', 'Kb', 'Mb', 'Gb', 'Tb', 'B', 'KB', 'MB', 'GB', 'TB' ];
+    , expected = [ 'mm', 'cm', 'm', 'km', 'in', 'ft', 'mi', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'mm3', 'cm3', 'ml', 'ltr', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3', 'ea', 'C', 'K', 'F', 'ms', 's', 'min', 'h','d', 'week', 'month', 'year', 'b', 'Kb', 'Mb', 'Gb', 'Tb', 'B', 'KB', 'MB', 'GB', 'TB' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/volumes.js
+++ b/test/volumes.js
@@ -8,8 +8,24 @@ tests['ltr to ltr'] = function () {
   assert.strictEqual( convert(2).from('ltr').to('ltr') , 2);
 };
 
+tests['mm3 to ltr'] = function () {
+  assert.strictEqual( convert(1000000).from('mm3').to('ltr') , 1);
+};
+
+tests['cm3 to ltr'] = function () {
+  assert.strictEqual( convert(100).from('cm3').to('ltr') , 1/10);
+};
+
 tests['ml to ltr'] = function () {
   assert.strictEqual( convert(100).from('ml').to('ltr') , 1/10);
+};
+
+tests['m3 to ltr'] = function () {
+  assert.strictEqual( convert(1).from('m3').to('ltr') , 1000);
+};
+
+tests['km3 to ltr'] = function () {
+  assert.strictEqual( convert(1).from('km3').to('ltr') , 1000000000000);
 };
 
 tests['ltr to ml'] = function () {
@@ -40,6 +56,34 @@ tests['Tbs to Tbs'] = function () {
 tests['tsp to ltr'] = function () {
   var expected = 1.75
     , actual = convert(355).from('tsp').to('ltr');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
+};
+
+tests['in3 to ltr'] = function () {
+  var expected = 0.0163871
+    , actual = convert(1).from('in3').to('ltr');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
+};
+
+tests['in3 to fl-oz'] = function () {
+  var expected = 0.554113
+    , actual = convert(1).from('in3').to('fl-oz');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
+};
+
+tests['m3 to yd3'] = function () {
+  var expected = 1.30795
+    , actual = convert(1).from('m3').to('yd3');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
+};
+
+tests['ft3 to cm3'] = function () {
+  var expected = 28316.8
+    , actual = convert(1).from('ft3').to('cm3');
   assert.ok( percentError(expected, actual) < ACCURACY
     , 'Expected: ' + expected +', Actual: ' + actual);
 };


### PR DESCRIPTION
Howdy,

Thanks for putting together this really convenient utility!

I'm working with a project that is going to be using some cubic measurements and it'd be really handy to be able to convert these into different measurements. This PR seeks to add the following cubic measurements to the volumes: `mm3`, `cm3`, `m3`, `km3`, `in3`, `ft3` and `yd3`.

Let me know what you think