### PR TITLE
Don’t perform any conversion if the “from” and “to” units are the same.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,11 @@ Converter.prototype.to = function (to) {
     this.throwUnsupportedUnitError(to);
   }
 
+  // Don't change the value if origin and destination are the same
+  if (this.origin.abbr === this.destination.abbr) {
+    return this.val;
+  }
+
   // You can't go from liquid to mass, for example
   if(this.destination.measure != this.origin.measure) {
     throw new Error('Cannot convert incompatible measures of '

--- a/test/lengths.js
+++ b/test/lengths.js
@@ -9,6 +9,10 @@ tests['ft to ft'] = function () {
   assert.strictEqual( convert(1).from('ft').to('ft') , 1);
 };
 
+tests['in to in'] = function () {
+  assert.strictEqual( convert(7).from('in').to('in') , 7);
+};
+
 tests['ft to in'] = function () {
   assert.strictEqual( convert(1).from('ft').to('in') , 12);
 };


### PR DESCRIPTION
`convert( 7 ).from( 'in' ).to( 'in' )` results in `6.999999999999999`, not `7`.

This fix simply passes through original values if the origin and destination measure/unit are the same.