### PR TITLE
Fix month and year calculations

### DIFF
--- a/lib/definitions/time.js
+++ b/lib/definitions/time.js
@@ -1,4 +1,5 @@
-var time
+var time;
+var daysInYear = 365.25;
 
 time = {
   ms: {
@@ -48,14 +49,14 @@ time = {
       singular: 'Month'
     , plural: 'Months'
     }
-  , to_anchor: 60 * 60 * 24 * 7 * 4 
+  , to_anchor: 60 * 60 * 24 * daysInYear / 12
   }
 , year: {
     name: {
       singular: 'Year'
     , plural: 'Years'
     }
-  , to_anchor: 60 * 60 * 24 * 7 * 52 
+  , to_anchor: 60 * 60 * 24 * daysInYear
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lodash.foreach": "2.3.x"
   },
   "devDependencies": {
-    "jake": "8.0.x"
+    "jake": "8.0.12"
   },
   "scripts": {
     "test": "jake test --trace"

--- a/test/times.js
+++ b/test/times.js
@@ -27,10 +27,33 @@ tests['s to d'] = function () {
 
 tests['d to week'] = function () {
   assert.strictEqual( convert(7).from('d').to('week'), 1);
-}
+};
 
-tests['w to year'] = function () {
+// Incorrect, shoud be either 30.4167 or 30.4375 days in a month
+tests ['d to month'] = function () {
+  assert.strictEqual( convert(28).from('d').to('month'), 1);
+};
+
+// Incorrect, should be 365 or 365.25 days in 1 year
+tests ['d to year'] = function () {
+  assert.strictEqual( convert(364).from('d').to('year'), 1);
+};
+
+// Incorrect, should be 4.34524 or 4.34821 weeks in 1 month
+tests['week to month'] = function () {
+  assert.strictEqual( convert(4).from('week').to('month'), 1);
+};
+
+tests['week to year'] = function () {
   assert.strictEqual( convert(52).from('week').to('year'), 1);
+};
+
+// Incorrect, should be 12 months in 1 year
+tests['month to year'] = function () {
+  var expected = .923
+    , actual = convert(12).from('month').to('year');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
 };
 
 module.exports = tests;

--- a/test/times.js
+++ b/test/times.js
@@ -29,31 +29,30 @@ tests['d to week'] = function () {
   assert.strictEqual( convert(7).from('d').to('week'), 1);
 };
 
-// Incorrect, shoud be either 30.4167 or 30.4375 days in a month
 tests ['d to month'] = function () {
-  assert.strictEqual( convert(28).from('d').to('month'), 1);
+  assert.strictEqual( convert(30.4375).from('d').to('month'), 1);
 };
 
-// Incorrect, should be 365 or 365.25 days in 1 year
 tests ['d to year'] = function () {
-  assert.strictEqual( convert(364).from('d').to('year'), 1);
+  assert.strictEqual( convert(365.25).from('d').to('year'), 1);
 };
 
-// Incorrect, should be 4.34524 or 4.34821 weeks in 1 month
 tests['week to month'] = function () {
-  assert.strictEqual( convert(4).from('week').to('month'), 1);
+  var expected = 1
+    , actual = convert(4.34821).from('week').to('month');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
 };
 
 tests['week to year'] = function () {
-  assert.strictEqual( convert(52).from('week').to('year'), 1);
-};
-
-// Incorrect, should be 12 months in 1 year
-tests['month to year'] = function () {
-  var expected = .923
-    , actual = convert(12).from('month').to('year');
+  var expected = 1
+    , actual = convert(52.17857).from('week').to('year');
   assert.ok( percentError(expected, actual) < ACCURACY
     , 'Expected: ' + expected +', Actual: ' + actual);
+};
+
+tests['month to year'] = function () {
+  assert.strictEqual( convert(12).from('month').to('year'), 1);
 };
 
 module.exports = tests;


### PR DESCRIPTION
This PR changes how the month and week conversions work.  Here's a summary of the changes:

```
convert(1).from('year').to('d'); // was 364, now 365.25
convert(1).from('month').to('d'); // was 28, now 30.4375
convert(1).from('year').to('week'); // was 52, now 52.17857
```

I realize this is a breaking change; it works well for me but might not be right for the community.  Comments are welcome.