### PR TITLE
Adds centilitre and decilitre definitons

### DIFF
--- a/lib/definitions/volume.js
+++ b/lib/definitions/volume.js
@@ -23,6 +23,20 @@ metric = {
     }
   , to_anchor: 1/1000
   }
+, cl: {
+    name: {
+      singular: 'Centilitre'
+    , plural: 'Centilitres'
+    }
+  , to_anchor: 1/100
+  }
+, dl: {
+    name: {
+      singular: 'Decilitre'
+    , plural: 'Decilitres'
+    }
+  , to_anchor: 1/10
+  }
 , l: {
     name: {
       singular: 'Litre'

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['l possibilities'] = function () {
   var actual = convert().from('l').possibilities()
-    , expected = [ 'mm3', 'cm3', 'ml', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
+    , expected = [ 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
   assert.deepEqual(actual, expected);
 };
 
@@ -34,7 +34,7 @@ tests['mass possibilities'] = function () {
 
 tests['volume possibilities'] = function () {
   var actual = convert().possibilities('volume')
-    , expected = [ 'mm3', 'cm3', 'ml', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
+    , expected = [ 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
   assert.deepEqual(actual, expected);
 };
 
@@ -70,7 +70,7 @@ tests['partsPer possibilities'] = function() {
 
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
-    , expected = [ 'mm', 'cm', 'm', 'km', 'in', 'yd', 'ft', 'mi', 'mm2', 'cm2', 'm2', 'ha', 'km2', 'in2', 'ft2', 'ac', 'mi2', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'mm3', 'cm3', 'ml', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3', 'ea', 'C', 'K', 'F', 'ms', 's', 'min', 'h','d', 'week', 'month', 'year', 'b', 'Kb', 'Mb', 'Gb', 'Tb', 'B', 'KB', 'MB', 'GB', 'TB', 'ppm', 'ppb', 'ppt', 'ppq' ];
+    , expected = [ 'mm', 'cm', 'm', 'km', 'in', 'yd', 'ft', 'mi', 'mm2', 'cm2', 'm2', 'ha', 'km2', 'in2', 'ft2', 'ac', 'mi2', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3', 'ea', 'C', 'K', 'F', 'ms', 's', 'min', 'h','d', 'week', 'month', 'year', 'b', 'Kb', 'Mb', 'Gb', 'Tb', 'B', 'KB', 'MB', 'GB', 'TB', 'ppm', 'ppb', 'ppt', 'ppq' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/volumes.js
+++ b/test/volumes.js
@@ -16,6 +16,14 @@ tests['cm3 to l'] = function () {
   assert.strictEqual( convert(100).from('cm3').to('l') , 1/10);
 };
 
+tests['dl to l'] = function () {
+  assert.strictEqual( convert(2).from('dl').to('l') , 0.2);
+};
+
+tests['cl to l'] = function () {
+  assert.strictEqual( convert(25).from('cl').to('l') , 0.25);
+};
+
 tests['ml to l'] = function () {
   assert.strictEqual( convert(100).from('ml').to('l') , 1/10);
 };

--- a/test/volumes.js
+++ b/test/volumes.js
@@ -32,6 +32,14 @@ tests['l to ml'] = function () {
   assert.strictEqual( convert(1).from('l').to('ml') , 1000);
 };
 
+tests['dl to ml'] = function () {
+  assert.strictEqual( convert(10).from('dl').to('ml') , 1000);
+};
+
+tests['cl to ml'] = function () {
+  assert.strictEqual( convert(100).from('cl').to('ml') , 1000);
+};
+
 tests['ml to ml'] = function () {
   assert.strictEqual( convert(13).from('ml').to('ml') , 13);
 };


### PR DESCRIPTION
At least in Sweden we use dl (decilitre 0.1 litre) and cl (centilitre 0.01 litre). I added them with tests.