### PR TITLE
Swedish volume measures

### DIFF
--- a/lib/definitions/volume.js
+++ b/lib/definitions/volume.js
@@ -58,6 +58,50 @@ metric = {
     }
   , to_anchor: 1000000000000
   }
+
+// Swedish units
+, krm: {
+  name: {
+    singular: 'Matsked'
+    , plural: 'Matskedar'
+  }
+  , to_anchor: 1/1000
+}
+, tsk: {
+    name: {
+      singular: 'Tesked'
+    , plural: 'Teskedar'
+    }
+  , to_anchor: 5/1000
+  }
+, msk: {
+    name: {
+      singular: 'Matsked'
+      , plural: 'Matskedar'
+    }
+    , to_anchor: 15/1000
+  }
+, kkp: {
+    name: {
+      singular: 'Kaffekopp'
+      , plural: 'Kaffekoppar'
+    }
+    , to_anchor: 150/1000
+  }
+, glas: {
+    name: {
+      singular: 'Glas'
+      , plural: 'Glas'
+    }
+    , to_anchor: 200/1000
+  }
+, kanna: {
+    name: {
+      singular: 'Kanna'
+    , plural: 'Kannor'
+    }
+  , to_anchor: 2.617
+  }
 };
 
 imperial = {

--- a/lib/definitions/volume.js
+++ b/lib/definitions/volume.js
@@ -23,6 +23,20 @@ metric = {
     }
   , to_anchor: 1/1000
   }
+, cl: {
+    name: {
+      singular: 'Centilitre'
+    , plural: 'Centilitres'
+    }
+  , to_anchor: 1/100
+  }
+, dl: {
+    name: {
+      singular: 'Decilitre'
+    , plural: 'Decilitres'
+    }
+  , to_anchor: 1/10
+  }
 , l: {
     name: {
       singular: 'Litre'

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['l possibilities'] = function () {
   var actual = convert().from('l').possibilities()
-    , expected = [ 'mm3', 'cm3', 'ml', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
+    , expected = [ 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
   assert.deepEqual(actual, expected);
 };
 
@@ -34,7 +34,7 @@ tests['mass possibilities'] = function () {
 
 tests['volume possibilities'] = function () {
   var actual = convert().possibilities('volume')
-    , expected = [ 'mm3', 'cm3', 'ml', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
+    , expected = [ 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
   assert.deepEqual(actual, expected);
 };
 
@@ -70,7 +70,7 @@ tests['partsPer possibilities'] = function() {
 
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
-    , expected = [ 'mm', 'cm', 'm', 'km', 'in', 'yd', 'ft', 'mi', 'mm2', 'cm2', 'm2', 'ha', 'km2', 'in2', 'ft2', 'ac', 'mi2', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'mm3', 'cm3', 'ml', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3', 'ea', 'C', 'K', 'F', 'ms', 's', 'min', 'h','d', 'week', 'month', 'year', 'b', 'Kb', 'Mb', 'Gb', 'Tb', 'B', 'KB', 'MB', 'GB', 'TB', 'ppm', 'ppb', 'ppt', 'ppq' ];
+    , expected = [ 'mm', 'cm', 'm', 'km', 'in', 'yd', 'ft', 'mi', 'mm2', 'cm2', 'm2', 'ha', 'km2', 'in2', 'ft2', 'ac', 'mi2', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3', 'ea', 'C', 'K', 'F', 'ms', 's', 'min', 'h','d', 'week', 'month', 'year', 'b', 'Kb', 'Mb', 'Gb', 'Tb', 'B', 'KB', 'MB', 'GB', 'TB', 'ppm', 'ppb', 'ppt', 'ppq' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['l possibilities'] = function () {
   var actual = convert().from('l').possibilities()
-    , expected = [ 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
+    , expected = [ 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'krm', 'tsk', 'msk', 'kkp', 'glas', 'kanna', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
   assert.deepEqual(actual, expected);
 };
 
@@ -34,7 +34,7 @@ tests['mass possibilities'] = function () {
 
 tests['volume possibilities'] = function () {
   var actual = convert().possibilities('volume')
-    , expected = [ 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
+    , expected = [ 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'krm', 'tsk', 'msk', 'kkp', 'glas', 'kanna', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
   assert.deepEqual(actual, expected);
 };
 
@@ -70,7 +70,7 @@ tests['partsPer possibilities'] = function() {
 
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
-    , expected = [ 'mm', 'cm', 'm', 'km', 'in', 'yd', 'ft', 'mi', 'mm2', 'cm2', 'm2', 'ha', 'km2', 'in2', 'ft2', 'ac', 'mi2', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3', 'ea', 'C', 'K', 'F', 'ms', 's', 'min', 'h','d', 'week', 'month', 'year', 'b', 'Kb', 'Mb', 'Gb', 'Tb', 'B', 'KB', 'MB', 'GB', 'TB', 'ppm', 'ppb', 'ppt', 'ppq' ];
+    , expected = [ 'mm', 'cm', 'm', 'km', 'in', 'yd', 'ft', 'mi', 'mm2', 'cm2', 'm2', 'ha', 'km2', 'in2', 'ft2', 'ac', 'mi2', 'mcg', 'mg', 'g', 'kg', 'oz', 'lb', 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'krm', 'tsk', 'msk', 'kkp', 'glas', 'kanna', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3', 'ea', 'C', 'K', 'F', 'ms', 's', 'min', 'h','d', 'week', 'month', 'year', 'b', 'Kb', 'Mb', 'Gb', 'Tb', 'B', 'KB', 'MB', 'GB', 'TB', 'ppm', 'ppb', 'ppt', 'ppq' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/volumes.js
+++ b/test/volumes.js
@@ -52,6 +52,54 @@ tests['ml to ml'] = function () {
   assert.strictEqual( convert(13).from('ml').to('ml') , 13);
 };
 
+tests['msk to ml'] = function () {
+  assert.strictEqual( convert(2).from('msk').to('ml') , 30);
+};
+
+tests['tsk to ml'] = function () {
+  assert.strictEqual( convert(3).from('tsk').to('ml') , 15);
+};
+
+tests['krm to ml'] = function () {
+  assert.strictEqual( convert(13).from('krm').to('ml') , 13);
+};
+
+tests['kanna to l'] = function () {
+  assert.strictEqual( convert(2).from('kanna').to('l') , 2 * 2.617);
+};
+
+tests['kkp to ml'] = function () {
+  assert.strictEqual( convert(2).from('kkp').to('ml') , 300);
+};
+
+tests['glas to ml'] = function () {
+  assert.strictEqual( convert(2).from('glas').to('ml') , 400);
+};
+
+tests['ml to msk'] = function () {
+  assert.strictEqual( convert(15).from('ml').to('msk') , 1);
+};
+
+tests['ml to tsk'] = function () {
+  assert.strictEqual( convert(5).from('ml').to('tsk') , 1);
+};
+
+tests['ml to krm'] = function () {
+  assert.strictEqual( convert(1).from('ml').to('krm') , 1);
+};
+
+tests['l to kanna'] = function () {
+  assert.strictEqual( convert(2.617).from('l').to('kanna') , 1);
+};
+
+tests['lm to kkp'] = function () {
+  assert.strictEqual( convert(150).from('ml').to('kkp') , 1);
+};
+
+tests['ml to glas'] = function () {
+  assert.strictEqual( convert(200).from('ml').to('glas') , 1);
+};
+
 tests['fl-oz to fl-oz'] = function () {
   assert.strictEqual( convert(62).from('fl-oz').to('fl-oz') , 62);
 };

--- a/test/volumes.js
+++ b/test/volumes.js
@@ -16,6 +16,14 @@ tests['cm3 to l'] = function () {
   assert.strictEqual( convert(100).from('cm3').to('l') , 1/10);
 };
 
+tests['dl to l'] = function () {
+  assert.strictEqual( convert(2).from('dl').to('l') , 0.2);
+};
+
+tests['cl to l'] = function () {
+  assert.strictEqual( convert(25).from('cl').to('l') , 0.25);
+};
+
 tests['ml to l'] = function () {
   assert.strictEqual( convert(100).from('ml').to('l') , 1/10);
 };

--- a/test/volumes.js
+++ b/test/volumes.js
@@ -32,6 +32,14 @@ tests['l to ml'] = function () {
   assert.strictEqual( convert(1).from('l').to('ml') , 1000);
 };
 
+tests['dl to ml'] = function () {
+  assert.strictEqual( convert(10).from('dl').to('ml') , 1000);
+};
+
+tests['cl to ml'] = function () {
+  assert.strictEqual( convert(100).from('cl').to('ml') , 1000);
+};
+
 tests['ml to ml'] = function () {
   assert.strictEqual( convert(13).from('ml').to('ml') , 13);
 };


### PR DESCRIPTION
Adds Swedish measurements for cooking.

References:
msk, krm, tsk, kkp, glas https://sv.wikipedia.org/wiki/Kokboksm%C3%A5tt
kanna https://sv.wikipedia.org/wiki/Kanna_(m%C3%A5tt)