### PR TITLE
Added definitions for electricity-related units

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,53 @@ Supported Units
   * ppt
   * ppq
 
+### Voltage
+  * V
+  * mV
+  * kV
+
+### Current
+  * A
+  * mA
+  * kA
+
+### Power
+  * W
+  * mW
+  * kW
+  * MW
+  * GW
+
+### Apparent Power
+  * VA
+  * mVA
+  * kVA
+  * MVA
+  * GVA
+
+### Reactive Power
+  * VAR
+  * mVAR
+  * kVAR
+  * MVAR
+  * GVAR
+
+### Energy
+  * Wh
+  * mWh
+  * kWh
+  * MWh
+  * GWh
+  * J
+  * kJ
+
+### Reactive Energy
+  * VARh
+  * mVARh
+  * kVARh
+  * MVARh
+  * GVARh
+
 ### Want More?
 
 Adding new measurement sets is easy. Take a look at [`lib/definitions`](https://github.com/ben-ng/convert-units/tree/master/lib/definitions) to see how it's done.

--- a/lib/definitions/apparentPower.js
+++ b/lib/definitions/apparentPower.js
@@ -1,0 +1,49 @@
+var apparentPower;
+
+apparentPower = {
+  VA: {
+    name: {
+      singular: 'Volt-Ampere'
+    , plural: 'Volt-Amperes'
+    }
+  , to_anchor: 1
+  }
+, mVA: {
+    name: {
+      singular: 'Millivolt-Ampere'
+      , plural: 'Millivolt-Amperes'
+    }
+    , to_anchor: .001
+  }
+, kVA: {
+    name: {
+      singular: 'Kilovolt-Ampere'
+    , plural: 'Kilovolt-Amperes'
+    }
+  , to_anchor: 1000
+  }
+, MVA: {
+    name: {
+      singular: 'Megavolt-Ampere'
+    , plural: 'Megavolt-Amperes'
+    }
+  , to_anchor: 1000000
+  }
+, GVA: {
+    name: {
+      singular: 'Gigavolt-Ampere'
+    , plural: 'Gigavolt-Amperes'
+    }
+  , to_anchor: 1000000000
+  }
+};
+
+module.exports = {
+  metric: apparentPower
+, _anchors: {
+    metric: {
+      unit: 'VA'
+    , ratio: 1
+    }
+  }
+};

--- a/lib/definitions/current.js
+++ b/lib/definitions/current.js
@@ -1,0 +1,35 @@
+var current;
+
+current = {
+  A: {
+    name: {
+      singular: 'Ampere'
+    , plural: 'Amperes'
+    }
+  , to_anchor: 1
+  }
+, mA: {
+    name: {
+      singular: 'Milliampere'
+      , plural: 'Milliamperes'
+    }
+    , to_anchor: .001
+  }
+, kA: {
+    name: {
+      singular: 'Kiloampere'
+    , plural: 'Kiloamperes'
+    }
+  , to_anchor: 1000
+  }
+};
+
+module.exports = {
+  metric: current
+, _anchors: {
+    metric: {
+      unit: 'A'
+    , ratio: 1
+    }
+  }
+};

--- a/lib/definitions/energy.js
+++ b/lib/definitions/energy.js
@@ -1,0 +1,63 @@
+var energy;
+
+energy = {
+  Wh: {
+    name: {
+      singular: 'Watt-hour'
+    , plural: 'Watt-hours'
+    }
+  , to_anchor: 3600
+  }
+, mWh: {
+    name: {
+      singular: 'Milliwatt-hour'
+      , plural: 'Milliwatt-hours'
+    }
+    , to_anchor: 3.6
+  }
+, kWh: {
+    name: {
+      singular: 'Kilowatt-hour'
+    , plural: 'Kilowatt-hours'
+    }
+  , to_anchor: 3600000
+  }
+, MWh: {
+    name: {
+      singular: 'Megawatt-hour'
+    , plural: 'Megawatt-hours'
+    }
+  , to_anchor: 3600000000
+  }
+, GWh: {
+    name: {
+      singular: 'Gigawatt-hour'
+    , plural: 'Gigawatt-hours'
+    }
+  , to_anchor: 3600000000000
+  }
+, J: {
+    name: {
+      singular: 'Joule'
+    , plural: 'Joules'
+    }
+  , to_anchor: 1
+  }
+, kJ: {
+    name: {
+      singular: 'Kilojoule'
+    , plural: 'Kilojoules'
+    }
+  , to_anchor: 1000
+  }
+};
+
+module.exports = {
+  metric: energy
+, _anchors: {
+    metric: {
+      unit: 'J'
+    , ratio: 1
+    }
+  }
+};

--- a/lib/definitions/power.js
+++ b/lib/definitions/power.js
@@ -1,0 +1,49 @@
+var power;
+
+power = {
+  W: {
+    name: {
+      singular: 'Watt'
+    , plural: 'Watts'
+    }
+  , to_anchor: 1
+  }
+, mW: {
+    name: {
+      singular: 'Milliwatt'
+      , plural: 'Milliwatts'
+    }
+    , to_anchor: .001
+  }
+, kW: {
+    name: {
+      singular: 'Kilowatt'
+    , plural: 'Kilowatts'
+    }
+  , to_anchor: 1000
+  }
+, MW: {
+    name: {
+      singular: 'Megawatt'
+    , plural: 'Megawatts'
+    }
+  , to_anchor: 1000000
+  }
+, GW: {
+    name: {
+      singular: 'Gigawatt'
+    , plural: 'Gigawatts'
+    }
+  , to_anchor: 1000000000
+  }
+};
+
+module.exports = {
+  metric: power
+, _anchors: {
+    metric: {
+      unit: 'W'
+    , ratio: 1
+    }
+  }
+};

--- a/lib/definitions/reactiveEnergy.js
+++ b/lib/definitions/reactiveEnergy.js
@@ -1,0 +1,49 @@
+var reactiveEnergy;
+
+reactiveEnergy = {
+  VARh: {
+    name: {
+      singular: 'Volt-Ampere Reactive Hour'
+    , plural: 'Volt-Amperes Reactive Hour'
+    }
+  , to_anchor: 1
+  }
+, mVARh: {
+    name: {
+      singular: 'Millivolt-Ampere Reactive Hour'
+      , plural: 'Millivolt-Amperes Reactive Hour'
+    }
+    , to_anchor: .001
+  }
+, kVARh: {
+    name: {
+      singular: 'Kilovolt-Ampere Reactive Hour'
+    , plural: 'Kilovolt-Amperes Reactive Hour'
+    }
+  , to_anchor: 1000
+  }
+, MVARh: {
+    name: {
+      singular: 'Megavolt-Ampere Reactive Hour'
+    , plural: 'Megavolt-Amperes Reactive Hour'
+    }
+  , to_anchor: 1000000
+  }
+, GVARh: {
+    name: {
+      singular: 'Gigavolt-Ampere Reactive Hour'
+    , plural: 'Gigavolt-Amperes Reactive Hour'
+    }
+  , to_anchor: 1000000000
+  }
+};
+
+module.exports = {
+  metric: reactiveEnergy
+, _anchors: {
+    metric: {
+      unit: 'VARh'
+    , ratio: 1
+    }
+  }
+};

--- a/lib/definitions/reactivePower.js
+++ b/lib/definitions/reactivePower.js
@@ -1,0 +1,49 @@
+var reactivePower;
+
+reactivePower = {
+  VAR: {
+    name: {
+      singular: 'Volt-Ampere Reactive'
+    , plural: 'Volt-Amperes Reactive'
+    }
+  , to_anchor: 1
+  }
+, mVAR: {
+    name: {
+      singular: 'Millivolt-Ampere Reactive'
+      , plural: 'Millivolt-Amperes Reactive'
+    }
+    , to_anchor: .001
+  }
+, kVAR: {
+    name: {
+      singular: 'Kilovolt-Ampere Reactive'
+    , plural: 'Kilovolt-Amperes Reactive'
+    }
+  , to_anchor: 1000
+  }
+, MVAR: {
+    name: {
+      singular: 'Megavolt-Ampere Reactive'
+    , plural: 'Megavolt-Amperes Reactive'
+    }
+  , to_anchor: 1000000
+  }
+, GVAR: {
+    name: {
+      singular: 'Gigavolt-Ampere Reactive'
+    , plural: 'Gigavolt-Amperes Reactive'
+    }
+  , to_anchor: 1000000000
+  }
+};
+
+module.exports = {
+  metric: reactivePower
+, _anchors: {
+    metric: {
+      unit: 'VAR'
+    , ratio: 1
+    }
+  }
+};

--- a/lib/definitions/voltage.js
+++ b/lib/definitions/voltage.js
@@ -1,0 +1,35 @@
+var voltage;
+
+voltage = {
+  V: {
+    name: {
+      singular: 'Volt'
+    , plural: 'Volts'
+    }
+  , to_anchor: 1
+  }
+, mV: {
+    name: {
+      singular: 'Millivolt'
+      , plural: 'Millivolts'
+    }
+    , to_anchor: .001
+  }
+, kV: {
+    name: {
+      singular: 'Kilovolt'
+    , plural: 'Kilovolts'
+    }
+  , to_anchor: 1000
+  }
+};
+
+module.exports = {
+  metric: voltage
+, _anchors: {
+    metric: {
+      unit: 'V'
+    , ratio: 1
+    }
+  }
+};

--- a/lib/definitions/volume.js
+++ b/lib/definitions/volume.js
@@ -44,6 +44,13 @@ metric = {
     }
   , to_anchor: 1
   }
+, kl: {
+    name: {
+      singular: 'Kilolitre'
+    , plural: 'Kilolitres'
+    }
+  , to_anchor: 1000
+  }
 , m3: {
     name: {
       singular: 'Cubic meter'

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ var convert
     , pressure: require('./definitions/pressure')
     , current: require('./definitions/current')
     , voltage: require('./definitions/voltage')
+    , power: require('./definitions/power')
     }
   , Converter;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ var convert
     , partsPer: require('./definitions/partsPer')
     , speed: require('./definitions/speed')
     , pressure: require('./definitions/pressure')
+    , current: require('./definitions/current')
     }
   , Converter;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ var convert
     , current: require('./definitions/current')
     , voltage: require('./definitions/voltage')
     , power: require('./definitions/power')
+    , reactivePower: require('./definitions/reactivePower')
     }
   , Converter;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ var convert
     , voltage: require('./definitions/voltage')
     , power: require('./definitions/power')
     , reactivePower: require('./definitions/reactivePower')
+    , apparentPower: require('./definitions/apparentPower')
     }
   , Converter;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ var convert
     , speed: require('./definitions/speed')
     , pressure: require('./definitions/pressure')
     , current: require('./definitions/current')
+    , voltage: require('./definitions/voltage')
     }
   , Converter;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -197,8 +197,15 @@ var describe = function(resp) {
 */
 Converter.prototype.describe = function (abbr) {
   var resp = Converter.prototype.getUnit(abbr);
+  var desc = null;
 
-  return describe(resp);
+  try {
+    desc = describe(resp);
+  } catch(err) {
+    this.throwUnsupportedUnitError(abbr);
+  }
+
+  return desc;
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ var convert
     , power: require('./definitions/power')
     , reactivePower: require('./definitions/reactivePower')
     , apparentPower: require('./definitions/apparentPower')
+    , energy: require('./definitions/energy')
     }
   , Converter;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ var convert
     , reactivePower: require('./definitions/reactivePower')
     , apparentPower: require('./definitions/apparentPower')
     , energy: require('./definitions/energy')
+    , reactiveEnergy: require('./definitions/reactiveEnergy')
     }
   , Converter;
 

--- a/test/apparentPower.js
+++ b/test/apparentPower.js
@@ -1,0 +1,65 @@
+var convert = require('../lib')
+  , assert = require('assert')
+  , tests = {};
+
+tests['VA to VA'] = function () {
+  assert.strictEqual( convert(1).from('VA').to('VA') , 1);
+};
+
+tests['mVA to mVA'] = function () {
+  assert.strictEqual( convert(1).from('mVA').to('mVA') , 1);
+};
+
+tests['kVA to kVA'] = function () {
+  assert.strictEqual( convert(1).from('kVA').to('kVA') , 1);
+};
+
+tests['MVA to MVA'] = function () {
+  assert.strictEqual( convert(1).from('MVA').to('MVA') , 1);
+};
+
+tests['GVA to GVA'] = function () {
+  assert.strictEqual( convert(1).from('GVA').to('GVA') , 1);
+};
+
+tests['VA to mVA'] = function () {
+  assert.strictEqual( convert(1).from('VA').to('mVA') , 1000);
+};
+
+tests['VA to kVA'] = function () {
+  assert.strictEqual( convert(1).from('VA').to('kVA') , 0.001);
+};
+
+tests['VA to MVA'] = function () {
+  assert.strictEqual( convert(1).from('VA').to('MVA') , 0.000001);
+};
+
+tests['VA to GVA'] = function () {
+  assert.strictEqual( convert(1).from('VA').to('GVA') , 0.000000001);
+};
+
+tests['GVA to mVA'] = function () {
+  assert.strictEqual( convert(1).from('GVA').to('mVA'), 1000000000000);
+}
+
+tests['MVA to mVA'] = function () {
+  assert.strictEqual( convert(1).from('MVA').to('mVA'), 1000000000);
+}
+
+tests['kVA to mVA'] = function () {
+  assert.strictEqual( convert(1).from('kVA').to('mVA'), 1000000);
+}
+
+tests['mVA to kVA'] = function () {
+  assert.strictEqual( convert(1).from('mVA').to('kVA'), 0.000001);
+}
+
+tests['mVA to VA'] = function () {
+  assert.strictEqual( convert(1).from('mVA').to('VA'), 0.001);
+}
+
+tests['kVA to VA'] = function () {
+  assert.strictEqual( convert(1).from('kVA').to('VA'), 1000);
+}
+
+module.exports = tests;

--- a/test/current.js
+++ b/test/current.js
@@ -1,0 +1,41 @@
+var convert = require('../lib')
+  , assert = require('assert')
+  , tests = {};
+
+tests['A to A'] = function () {
+  assert.strictEqual( convert(1).from('A').to('A') , 1);
+};
+
+tests['mA to mA'] = function () {
+  assert.strictEqual( convert(1).from('mA').to('mA') , 1);
+};
+
+tests['kA to kA'] = function () {
+  assert.strictEqual( convert(1).from('kA').to('kA') , 1);
+};
+
+tests['A to mA'] = function () {
+  assert.strictEqual( convert(1).from('A').to('mA') , 1000);
+};
+
+tests['A to kA'] = function () {
+  assert.strictEqual( convert(1).from('A').to('kA') , 0.001);
+};
+
+tests['kA to mA'] = function () {
+  assert.strictEqual( convert(1).from('kA').to('mA'), 1000000);
+}
+
+tests['mA to kA'] = function () {
+  assert.strictEqual( convert(1).from('mA').to('kA'), 0.000001);
+}
+
+tests['mA to A'] = function () {
+  assert.strictEqual( convert(1).from('mA').to('A'), 0.001);
+}
+
+tests['kA to A'] = function () {
+  assert.strictEqual( convert(1).from('kA').to('A'), 1000);
+}
+
+module.exports = tests;

--- a/test/energy.js
+++ b/test/energy.js
@@ -1,0 +1,85 @@
+var convert = require('../lib')
+  , assert = require('assert')
+  , tests = {};
+
+tests['Wh to Wh'] = function () {
+  assert.strictEqual( convert(1).from('Wh').to('Wh') , 1);
+};
+
+tests['mWh to mWh'] = function () {
+  assert.strictEqual( convert(1).from('mWh').to('mWh') , 1);
+};
+
+tests['kWh to kWh'] = function () {
+  assert.strictEqual( convert(1).from('kWh').to('kWh') , 1);
+};
+
+tests['MWh to MWh'] = function () {
+  assert.strictEqual( convert(1).from('MWh').to('MWh') , 1);
+};
+
+tests['GWh to GWh'] = function () {
+  assert.strictEqual( convert(1).from('GWh').to('GWh') , 1);
+};
+
+tests['J to J'] = function () {
+  assert.strictEqual( convert(1).from('J').to('J') , 1);
+};
+
+tests['kJ to kJ'] = function () {
+  assert.strictEqual( convert(1).from('kJ').to('kJ') , 1);
+};
+
+tests['Wh to J'] = function () {
+  assert.strictEqual( convert(1).from('Wh').to('J') , 3600);
+};
+
+tests['Wh to mWh'] = function () {
+  assert.strictEqual( convert(1).from('Wh').to('mWh') , 1000);
+};
+
+tests['Wh to kWh'] = function () {
+  assert.strictEqual( convert(1).from('Wh').to('kWh') , 0.001);
+};
+
+tests['Wh to MWh'] = function () {
+  assert.strictEqual( convert(1).from('Wh').to('MWh') , 0.000001);
+};
+
+tests['Wh to GWh'] = function () {
+  assert.strictEqual( convert(1).from('Wh').to('GWh') , 0.000000001);
+};
+
+tests['GWh to mWh'] = function () {
+  assert.strictEqual( convert(1).from('GWh').to('mWh'), 1000000000000);
+}
+
+tests['GWh to J'] = function () {
+  assert.strictEqual( convert(1).from('GWh').to('J'), 3600000000000);
+}
+
+tests['MWh to mWh'] = function () {
+  assert.strictEqual( convert(1).from('MWh').to('mWh'), 1000000000);
+}
+
+tests['kWh to mWh'] = function () {
+  assert.strictEqual( convert(1).from('kWh').to('mWh'), 1000000);
+}
+
+tests['mWh to kWh'] = function () {
+  assert.strictEqual( convert(1).from('mWh').to('kWh'), 0.000001);
+}
+
+tests['mWh to Wh'] = function () {
+  assert.strictEqual( convert(1).from('mWh').to('Wh'), 0.001);
+}
+
+tests['kWh to Wh'] = function () {
+  assert.strictEqual( convert(1).from('kWh').to('Wh'), 1000);
+}
+
+tests['kWh to kJ'] = function () {
+  assert.strictEqual( convert(1).from('kWh').to('kJ'), 3600);
+}
+
+module.exports = tests;

--- a/test/measures.js
+++ b/test/measures.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['measures'] = function () {
   var actual = convert().measures()
-    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure' ];
+    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/measures.js
+++ b/test/measures.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['measures'] = function () {
   var actual = convert().measures()
-    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage', 'power' ];
+    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage', 'power', 'reactivePower' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/measures.js
+++ b/test/measures.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['measures'] = function () {
   var actual = convert().measures()
-    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage', 'power', 'reactivePower', 'apparentPower', 'energy' ];
+    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage', 'power', 'reactivePower', 'apparentPower', 'energy', 'reactiveEnergy' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/measures.js
+++ b/test/measures.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['measures'] = function () {
   var actual = convert().measures()
-    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage', 'power', 'reactivePower' ];
+    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage', 'power', 'reactivePower', 'apparentPower' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/measures.js
+++ b/test/measures.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['measures'] = function () {
   var actual = convert().measures()
-    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage' ];
+    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage', 'power' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/measures.js
+++ b/test/measures.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['measures'] = function () {
   var actual = convert().measures()
-    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage', 'power', 'reactivePower', 'apparentPower' ];
+    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage', 'power', 'reactivePower', 'apparentPower', 'energy' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/measures.js
+++ b/test/measures.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['measures'] = function () {
   var actual = convert().measures()
-    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current' ];
+    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -94,6 +94,12 @@ tests['voltage possibilities'] = function() {
   assert.deepEqual(actual.sort(), expected.sort())
 };
 
+tests['power possibilities'] = function() {
+  var actual = convert().possibilities('power')
+    , expected = [ 'W', 'mW', 'kW', 'MW', 'GW'];
+  assert.deepEqual(actual.sort(), expected.sort())
+};
+
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
     // Please keep these sorted for maintainability
@@ -133,6 +139,7 @@ tests['all possibilities'] = function () {
       , 'g'
       , 'gal'
       , 'glas'
+      , 'GW'
       , 'h'
       , 'hPa'
       , 'ha'
@@ -153,6 +160,7 @@ tests['all possibilities'] = function () {
       , 'krm'
       , 'ksi'
       , 'kV'
+      , 'kW'
       , 'l'
       , 'lb'
       , 'm'
@@ -175,6 +183,8 @@ tests['all possibilities'] = function () {
       , 'msk'
       , 'mu'
       , 'mV'
+      , 'mW'
+      , 'MW'
       , 'ns'
       , 'oz'
       , 'pnt'
@@ -189,6 +199,7 @@ tests['all possibilities'] = function () {
       , 'tsk'
       , 'tsp'
       , 'V'
+      , 'W'
       , 'week'
       , 'yd'
       , 'yd2'

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -88,6 +88,12 @@ tests['current possibilities'] = function() {
   assert.deepEqual(actual.sort(), expected.sort())
 };
 
+tests['voltage possibilities'] = function() {
+  var actual = convert().possibilities('voltage')
+    , expected = [ 'V', 'mV', 'kV'];
+  assert.deepEqual(actual.sort(), expected.sort())
+};
+
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
     // Please keep these sorted for maintainability
@@ -146,6 +152,7 @@ tests['all possibilities'] = function () {
       , 'knot'
       , 'krm'
       , 'ksi'
+      , 'kV'
       , 'l'
       , 'lb'
       , 'm'
@@ -167,6 +174,7 @@ tests['all possibilities'] = function () {
       , 'ms'
       , 'msk'
       , 'mu'
+      , 'mV'
       , 'ns'
       , 'oz'
       , 'pnt'
@@ -180,6 +188,7 @@ tests['all possibilities'] = function () {
       , 'torr'
       , 'tsk'
       , 'tsp'
+      , 'V'
       , 'week'
       , 'yd'
       , 'yd2'

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -82,11 +82,18 @@ tests['speed possibilities'] = function() {
   assert.deepEqual(actual.sort(), expected.sort())
 };
 
+tests['current possibilities'] = function() {
+  var actual = convert().possibilities('current')
+    , expected = [ 'A', 'mA', 'kA'];
+  assert.deepEqual(actual.sort(), expected.sort())
+};
+
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
     // Please keep these sorted for maintainability
     , expected = [
-        'B'
+        'A'
+      , 'B'
       , 'C'
       , 'F'
       , 'GB'
@@ -126,6 +133,7 @@ tests['all possibilities'] = function () {
       , 'in'
       , 'in2'
       , 'in3'
+      , 'kA'
       , 'kPa'
       , 'kanna'
       , 'kg'
@@ -145,6 +153,7 @@ tests['all possibilities'] = function () {
       , 'm/s'
       , 'm2'
       , 'm3'
+      , 'mA'
       , 'mcg'
       , 'mg'
       , 'mi'

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -112,6 +112,12 @@ tests['apparent power possibilities'] = function() {
   assert.deepEqual(actual.sort(), expected.sort())
 };
 
+tests['energy possibilities'] = function() {
+  var actual = convert().possibilities('energy')
+    , expected = [ 'Wh', 'mWh', 'kWh', 'MWh', 'GWh', 'J', 'kJ'];
+  assert.deepEqual(actual.sort(), expected.sort())
+};
+
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
     // Please keep these sorted for maintainability
@@ -154,17 +160,20 @@ tests['all possibilities'] = function () {
       , 'GVA'
       , 'GVAR'
       , 'GW'
+      , 'GWh'
       , 'h'
       , 'hPa'
       , 'ha'
       , 'in'
       , 'in2'
       , 'in3'
+      , 'J'
       , 'kA'
       , 'kPa'
       , 'kanna'
       , 'kg'
       , 'kkp'
+      , 'kJ'
       , 'kl'
       , 'km'
       , 'km/h'
@@ -177,6 +186,7 @@ tests['all possibilities'] = function () {
       , 'kVA'
       , 'kVAR'
       , 'kW'
+      , 'kWh'
       , 'l'
       , 'lb'
       , 'm'
@@ -205,6 +215,8 @@ tests['all possibilities'] = function () {
       , 'MVAR'
       , 'mW'
       , 'MW'
+      , 'mWh'
+      , 'MWh'
       , 'ns'
       , 'oz'
       , 'pnt'
@@ -223,6 +235,7 @@ tests['all possibilities'] = function () {
       , 'VAR'
       , 'W'
       , 'week'
+      , 'Wh'
       , 'yd'
       , 'yd2'
       , 'yd3'

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -118,6 +118,12 @@ tests['energy possibilities'] = function() {
   assert.deepEqual(actual.sort(), expected.sort())
 };
 
+tests['reactive energy possibilities'] = function() {
+  var actual = convert().possibilities('reactiveEnergy')
+    , expected = [ 'VARh', 'mVARh', 'kVARh', 'MVARh', 'GVARh'];
+  assert.deepEqual(actual.sort(), expected.sort())
+};
+
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
     // Please keep these sorted for maintainability
@@ -159,6 +165,7 @@ tests['all possibilities'] = function () {
       , 'glas'
       , 'GVA'
       , 'GVAR'
+      , 'GVARh'
       , 'GW'
       , 'GWh'
       , 'h'
@@ -185,6 +192,7 @@ tests['all possibilities'] = function () {
       , 'kV'
       , 'kVA'
       , 'kVAR'
+      , 'kVARh'
       , 'kW'
       , 'kWh'
       , 'l'
@@ -213,6 +221,8 @@ tests['all possibilities'] = function () {
       , 'MVA'
       , 'mVAR'
       , 'MVAR'
+      , 'mVARh'
+      , 'MVARh'
       , 'mW'
       , 'MW'
       , 'mWh'
@@ -233,6 +243,7 @@ tests['all possibilities'] = function () {
       , 'V'
       , 'VA'
       , 'VAR'
+      , 'VARh'
       , 'W'
       , 'week'
       , 'Wh'

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -106,6 +106,12 @@ tests['reactive power possibilities'] = function() {
   assert.deepEqual(actual.sort(), expected.sort())
 };
 
+tests['apparent power possibilities'] = function() {
+  var actual = convert().possibilities('apparentPower')
+    , expected = [ 'VA', 'mVA', 'kVA', 'MVA', 'GVA'];
+  assert.deepEqual(actual.sort(), expected.sort())
+};
+
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
     // Please keep these sorted for maintainability
@@ -145,6 +151,7 @@ tests['all possibilities'] = function () {
       , 'g'
       , 'gal'
       , 'glas'
+      , 'GVA'
       , 'GVAR'
       , 'GW'
       , 'h'
@@ -167,8 +174,9 @@ tests['all possibilities'] = function () {
       , 'krm'
       , 'ksi'
       , 'kV'
-      , 'kW'
+      , 'kVA'
       , 'kVAR'
+      , 'kW'
       , 'l'
       , 'lb'
       , 'm'
@@ -191,6 +199,8 @@ tests['all possibilities'] = function () {
       , 'msk'
       , 'mu'
       , 'mV'
+      , 'mVA'
+      , 'MVA'
       , 'mVAR'
       , 'MVAR'
       , 'mW'
@@ -209,6 +219,7 @@ tests['all possibilities'] = function () {
       , 'tsk'
       , 'tsp'
       , 'V'
+      , 'VA'
       , 'VAR'
       , 'W'
       , 'week'

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -100,6 +100,12 @@ tests['power possibilities'] = function() {
   assert.deepEqual(actual.sort(), expected.sort())
 };
 
+tests['reactive power possibilities'] = function() {
+  var actual = convert().possibilities('reactivePower')
+    , expected = [ 'VAR', 'mVAR', 'kVAR', 'MVAR', 'GVAR'];
+  assert.deepEqual(actual.sort(), expected.sort())
+};
+
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
     // Please keep these sorted for maintainability
@@ -139,6 +145,7 @@ tests['all possibilities'] = function () {
       , 'g'
       , 'gal'
       , 'glas'
+      , 'GVAR'
       , 'GW'
       , 'h'
       , 'hPa'
@@ -161,6 +168,7 @@ tests['all possibilities'] = function () {
       , 'ksi'
       , 'kV'
       , 'kW'
+      , 'kVAR'
       , 'l'
       , 'lb'
       , 'm'
@@ -183,6 +191,8 @@ tests['all possibilities'] = function () {
       , 'msk'
       , 'mu'
       , 'mV'
+      , 'mVAR'
+      , 'MVAR'
       , 'mW'
       , 'MW'
       , 'ns'
@@ -199,6 +209,7 @@ tests['all possibilities'] = function () {
       , 'tsk'
       , 'tsp'
       , 'V'
+      , 'VAR'
       , 'W'
       , 'week'
       , 'yd'

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -6,7 +6,7 @@ assert.options.strict = true;
 
 tests['l possibilities'] = function () {
   var actual = convert().from('l').possibilities()
-    , expected = [ 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'krm', 'tsk', 'msk', 'kkp', 'glas', 'kanna', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
+    , expected = [ 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'kl', 'm3', 'km3', 'krm', 'tsk', 'msk', 'kkp', 'glas', 'kanna', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
   assert.deepEqual(actual.sort(), expected.sort())
 };
 
@@ -36,7 +36,7 @@ tests['mass possibilities'] = function () {
 
 tests['volume possibilities'] = function () {
   var actual = convert().possibilities('volume')
-    , expected = [ 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'm3', 'km3', 'krm', 'tsk', 'msk', 'kkp', 'glas', 'kanna', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
+    , expected = [ 'mm3', 'cm3', 'ml', 'cl', 'dl', 'l', 'kl', 'm3', 'km3', 'krm', 'tsk', 'msk', 'kkp', 'glas', 'kanna', 'tsp', 'Tbs', 'in3', 'fl-oz', 'cup', 'pnt', 'qt', 'gal', 'ft3', 'yd3' ];
   assert.deepEqual(actual.sort(), expected.sort())
 };
 
@@ -130,6 +130,7 @@ tests['all possibilities'] = function () {
       , 'kanna'
       , 'kg'
       , 'kkp'
+      , 'kl'
       , 'km'
       , 'km/h'
       , 'km2'

--- a/test/power.js
+++ b/test/power.js
@@ -1,0 +1,65 @@
+var convert = require('../lib')
+  , assert = require('assert')
+  , tests = {};
+
+tests['W to W'] = function () {
+  assert.strictEqual( convert(1).from('W').to('W') , 1);
+};
+
+tests['mW to mW'] = function () {
+  assert.strictEqual( convert(1).from('mW').to('mW') , 1);
+};
+
+tests['kW to kW'] = function () {
+  assert.strictEqual( convert(1).from('kW').to('kW') , 1);
+};
+
+tests['MW to MW'] = function () {
+  assert.strictEqual( convert(1).from('MW').to('MW') , 1);
+};
+
+tests['GW to GW'] = function () {
+  assert.strictEqual( convert(1).from('GW').to('GW') , 1);
+};
+
+tests['W to mW'] = function () {
+  assert.strictEqual( convert(1).from('W').to('mW') , 1000);
+};
+
+tests['W to kW'] = function () {
+  assert.strictEqual( convert(1).from('W').to('kW') , 0.001);
+};
+
+tests['W to MW'] = function () {
+  assert.strictEqual( convert(1).from('W').to('MW') , 0.000001);
+};
+
+tests['W to GW'] = function () {
+  assert.strictEqual( convert(1).from('W').to('GW') , 0.000000001);
+};
+
+tests['GW to mW'] = function () {
+  assert.strictEqual( convert(1).from('GW').to('mW'), 1000000000000);
+}
+
+tests['MW to mW'] = function () {
+  assert.strictEqual( convert(1).from('MW').to('mW'), 1000000000);
+}
+
+tests['kW to mW'] = function () {
+  assert.strictEqual( convert(1).from('kW').to('mW'), 1000000);
+}
+
+tests['mW to kW'] = function () {
+  assert.strictEqual( convert(1).from('mW').to('kW'), 0.000001);
+}
+
+tests['mW to W'] = function () {
+  assert.strictEqual( convert(1).from('mW').to('W'), 0.001);
+}
+
+tests['kW to W'] = function () {
+  assert.strictEqual( convert(1).from('kW').to('W'), 1000);
+}
+
+module.exports = tests;

--- a/test/reactiveEnergy.js
+++ b/test/reactiveEnergy.js
@@ -1,0 +1,65 @@
+var convert = require('../lib')
+  , assert = require('assert')
+  , tests = {};
+
+tests['VARh to VARh'] = function () {
+  assert.strictEqual( convert(1).from('VARh').to('VARh') , 1);
+};
+
+tests['mVARh to mVARh'] = function () {
+  assert.strictEqual( convert(1).from('mVARh').to('mVARh') , 1);
+};
+
+tests['kVARh to kVARh'] = function () {
+  assert.strictEqual( convert(1).from('kVARh').to('kVARh') , 1);
+};
+
+tests['MVARh to MVARh'] = function () {
+  assert.strictEqual( convert(1).from('MVARh').to('MVARh') , 1);
+};
+
+tests['GVARh to GVARh'] = function () {
+  assert.strictEqual( convert(1).from('GVARh').to('GVARh') , 1);
+};
+
+tests['VARh to mVARh'] = function () {
+  assert.strictEqual( convert(1).from('VARh').to('mVARh') , 1000);
+};
+
+tests['VARh to kVARh'] = function () {
+  assert.strictEqual( convert(1).from('VARh').to('kVARh') , 0.001);
+};
+
+tests['VARh to MVARh'] = function () {
+  assert.strictEqual( convert(1).from('VARh').to('MVARh') , 0.000001);
+};
+
+tests['VARh to GVARh'] = function () {
+  assert.strictEqual( convert(1).from('VARh').to('GVARh') , 0.000000001);
+};
+
+tests['GVARh to mVARh'] = function () {
+  assert.strictEqual( convert(1).from('GVARh').to('mVARh'), 1000000000000);
+}
+
+tests['MVARh to mVARh'] = function () {
+  assert.strictEqual( convert(1).from('MVARh').to('mVARh'), 1000000000);
+}
+
+tests['kVARh to mVARh'] = function () {
+  assert.strictEqual( convert(1).from('kVARh').to('mVARh'), 1000000);
+}
+
+tests['mVARh to kVARh'] = function () {
+  assert.strictEqual( convert(1).from('mVARh').to('kVARh'), 0.000001);
+}
+
+tests['mVARh to VARh'] = function () {
+  assert.strictEqual( convert(1).from('mVARh').to('VARh'), 0.001);
+}
+
+tests['kVARh to VARh'] = function () {
+  assert.strictEqual( convert(1).from('kVARh').to('VARh'), 1000);
+}
+
+module.exports = tests;

--- a/test/reactivePower.js
+++ b/test/reactivePower.js
@@ -1,0 +1,65 @@
+var convert = require('../lib')
+  , assert = require('assert')
+  , tests = {};
+
+tests['VAR to VAR'] = function () {
+  assert.strictEqual( convert(1).from('VAR').to('VAR') , 1);
+};
+
+tests['mVAR to mVAR'] = function () {
+  assert.strictEqual( convert(1).from('mVAR').to('mVAR') , 1);
+};
+
+tests['kVAR to kVAR'] = function () {
+  assert.strictEqual( convert(1).from('kVAR').to('kVAR') , 1);
+};
+
+tests['MVAR to MVAR'] = function () {
+  assert.strictEqual( convert(1).from('MVAR').to('MVAR') , 1);
+};
+
+tests['GVAR to GVAR'] = function () {
+  assert.strictEqual( convert(1).from('GVAR').to('GVAR') , 1);
+};
+
+tests['VAR to mVAR'] = function () {
+  assert.strictEqual( convert(1).from('VAR').to('mVAR') , 1000);
+};
+
+tests['VAR to kVAR'] = function () {
+  assert.strictEqual( convert(1).from('VAR').to('kVAR') , 0.001);
+};
+
+tests['VAR to MVAR'] = function () {
+  assert.strictEqual( convert(1).from('VAR').to('MVAR') , 0.000001);
+};
+
+tests['VAR to GVAR'] = function () {
+  assert.strictEqual( convert(1).from('VAR').to('GVAR') , 0.000000001);
+};
+
+tests['GVAR to mVAR'] = function () {
+  assert.strictEqual( convert(1).from('GVAR').to('mVAR'), 1000000000000);
+}
+
+tests['MVAR to mVAR'] = function () {
+  assert.strictEqual( convert(1).from('MVAR').to('mVAR'), 1000000000);
+}
+
+tests['kVAR to mVAR'] = function () {
+  assert.strictEqual( convert(1).from('kVAR').to('mVAR'), 1000000);
+}
+
+tests['mVAR to kVAR'] = function () {
+  assert.strictEqual( convert(1).from('mVAR').to('kVAR'), 0.000001);
+}
+
+tests['mVAR to VAR'] = function () {
+  assert.strictEqual( convert(1).from('mVAR').to('VAR'), 0.001);
+}
+
+tests['kVAR to VAR'] = function () {
+  assert.strictEqual( convert(1).from('kVAR').to('VAR'), 1000);
+}
+
+module.exports = tests;

--- a/test/voltage.js
+++ b/test/voltage.js
@@ -1,0 +1,41 @@
+var convert = require('../lib')
+  , assert = require('assert')
+  , tests = {};
+
+tests['V to V'] = function () {
+  assert.strictEqual( convert(1).from('V').to('V') , 1);
+};
+
+tests['mV to mV'] = function () {
+  assert.strictEqual( convert(1).from('mV').to('mV') , 1);
+};
+
+tests['kV to kV'] = function () {
+  assert.strictEqual( convert(1).from('kV').to('kV') , 1);
+};
+
+tests['V to mV'] = function () {
+  assert.strictEqual( convert(1).from('V').to('mV') , 1000);
+};
+
+tests['V to kV'] = function () {
+  assert.strictEqual( convert(1).from('V').to('kV') , 0.001);
+};
+
+tests['kV to mV'] = function () {
+  assert.strictEqual( convert(1).from('kV').to('mV'), 1000000);
+}
+
+tests['mV to kV'] = function () {
+  assert.strictEqual( convert(1).from('mV').to('kV'), 0.000001);
+}
+
+tests['mV to V'] = function () {
+  assert.strictEqual( convert(1).from('mV').to('V'), 0.001);
+}
+
+tests['kV to V'] = function () {
+  assert.strictEqual( convert(1).from('kV').to('V'), 1000);
+}
+
+module.exports = tests;


### PR DESCRIPTION
New definitions for:

- current (Ampere)
- voltage (Volt)
- power (Watt)
- reactive power (Volt-Ampere Reactive)
- apparent power (Volt-Ampere)
- energy (Watt hour & Joule)
- reactive energy (Volt-Ampere Reactive hour)

README.md updated with list of new definitions.
All test units updated as well.