### PR TITLE
Add absence of units to be able to just count things

### DIFF
--- a/lib/definitions/none.js
+++ b/lib/definitions/none.js
@@ -1,0 +1,22 @@
+var none;
+
+none = {
+  '': {
+    name: {
+      singular: ''
+    , plural: ''
+    }
+  , to_anchor: 1
+  }
+};
+
+
+module.exports = {
+  metric: none 
+, _anchors: {
+    metric: {
+      unit: ''
+    , ratio: 1
+    }
+  }
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ var convert
     , partsPer: require('./definitions/partsPer')
     , speed: require('./definitions/speed')
     , pressure: require('./definitions/pressure')
+    , none: require('./definitions/none')
     }
   , Converter;
 


### PR DESCRIPTION
To remain general, having no dimension should be supported.

Example:
I have 3 apples. I want to convert that to meters. That should throw.

My use case deals with both weight, volume and no unit.

Any thoughts? :)