### PR TITLE
Enable "cut off number" customization when switching to the next order of magnitude within a unit of measure.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -123,9 +123,10 @@ Converter.prototype.toBest = function(options) {
   if(!this.origin)
     throw new Error('.toBest must be called after .from');
 
-  if (options == null) {
-      options = { exclude: [] };
-  }
+  var options = Object.assign({
+    exclude: [],
+    cutOffNumber: 1,
+  }, options)
 
   var best;
   /**
@@ -139,7 +140,7 @@ Converter.prototype.toBest = function(options) {
 
     if (isIncluded && unit.system === this.origin.system) {
       var result = this.to(possibility);
-      if (!best || (result >= 1 && result < best.val)) {
+      if (!best || (result >= options.cutOffNumber && result < best.val)) {
         best = {
           val: result,
           unit: possibility,


### PR DESCRIPTION
I needed to control when numbers jump to the next currency.

We still wanted to show 1000 values in the lower currency, eg.

Example: 1 000 000 W should display as 1000 kW, not 1mW.

To do this i can now pass the option {cutOffNumber: 10} to the best function.