### PR TITLE
Adding frequency measures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,18 @@ Supported Units
   * month
   * year
 
+### Frequency
+
+  * Hz
+  * mHz
+  * kHz
+  * MHz
+  * GHz
+  * THz
+  * rpm
+  * deg/s
+  * rad/s
+
 ### Speed
 
   * m/s

--- a/lib/definitions/frequency.js
+++ b/lib/definitions/frequency.js
@@ -1,0 +1,78 @@
+var frequency;
+
+frequency = {
+  mHz: {
+    name: {
+      singular: 'millihertz'
+    , plural: 'millihertz'
+    }
+  , to_anchor: 1/1000
+  }
+, Hz: {
+    name: {
+      singular: 'hertz'
+    , plural: 'hertz'
+    }
+  , to_anchor: 1
+  }
+, kHz: {
+    name: {
+      singular: 'kilohertz'
+    , plural: 'kilohertz'
+    }
+  , to_anchor: 1000
+  }
+, MHz: {
+    name: {
+      singular: 'megahertz'
+    , plural: 'megahertz'
+    }
+  , to_anchor: 1000 * 1000
+  }
+, GHz: {
+    name: {
+      singular: 'gigahertz'
+    , plural: 'gigahertz'
+    }
+  , to_anchor: 1000 * 1000 * 1000
+  }
+, THz: {
+    name: {
+      singular: 'terahertz'
+    , plural: 'terahertz'
+    }
+  , to_anchor: 1000 * 1000 * 1000 * 1000
+  }
+, rpm: {
+    name: {
+      singular: 'rotation per minute'
+    , plural: 'rotations per minute'
+    }
+  , to_anchor: 1/60
+  }
+, "deg/s": {
+    name: {
+      singular: 'degree per second'
+    , plural: 'degrees per second'
+    }
+  , to_anchor: 1/360
+  }
+, "rad/s": {
+    name: {
+      singular: 'radian per second'
+    , plural: 'radians per second'
+    }
+  , to_anchor: 1/(Math.PI * 2)
+  }
+};
+
+
+module.exports = {
+  metric: frequency
+, _anchors: {
+    frequency: {
+      unit: 'hz'
+    , ratio: 1
+    }
+  }
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ var convert
     , energy: require('./definitions/energy')
     , reactiveEnergy: require('./definitions/reactiveEnergy')
     , volumeFlowRate: require('./definitions/volumeFlowRate')
+    , frequency: require('./definitions/frequency')
     }
   , Converter;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,8 +21,8 @@ var convert
     , energy: require('./definitions/energy')
     , reactiveEnergy: require('./definitions/reactiveEnergy')
     , volumeFlowRate: require('./definitions/volumeFlowRate')
-    , frequency: require('./definitions/frequency')
     , illuminance: require('./definitions/illuminance')
+    , frequency: require('./definitions/frequency')
     }
   , Converter;
 

--- a/test/frequency.js
+++ b/test/frequency.js
@@ -1,0 +1,63 @@
+var convert = require('../lib')
+  , assert = require('assert')
+  , tests = {};
+
+tests['Hz to Hz'] = function () {
+  assert.strictEqual( convert(1).from('Hz').to('Hz') , 1);
+};
+
+tests['mHz to mHz'] = function () {
+  assert.strictEqual( convert(1).from('mHz').to('mHz') , 1);
+};
+
+tests['kHz to kHz'] = function () {
+  assert.strictEqual( convert(1).from('kHz').to('kHz') , 1);
+};
+
+tests['MHz to MHz'] = function () {
+  assert.strictEqual( convert(1).from('MHz').to('MHz') , 1);
+};
+
+tests['GHz to GHz'] = function () {
+  assert.strictEqual( convert(1).from('GHz').to('GHz') , 1);
+};
+
+tests['THz to THz'] = function () {
+  assert.strictEqual( convert(1).from('THz').to('THz') , 1);
+};
+
+tests['rpm to rpm'] = function () {
+  assert.strictEqual( convert(1).from('rpm').to('rpm') , 1);
+};
+
+tests['deg/s to deg/s'] = function () {
+  assert.strictEqual( convert(1).from('deg/s').to('deg/s') , 1);
+};
+
+tests['rad/s to rad/s'] = function () {
+  assert.strictEqual( convert(1).from('rad/s').to('rad/s') , 1);
+};
+
+tests['rpm to Hz'] = function () {
+  assert.strictEqual( convert(60).from('rpm').to('Hz') , 1);
+};
+
+tests['deg/s to Hz'] = function () {
+  assert.strictEqual( convert(360).from('deg/s').to('Hz') , 1);
+};
+
+tests['rad/s to Hz'] = function () {
+  assert.strictEqual( convert(Math.PI).from('rad/s').to('Hz') , 0.5);
+};
+
+tests['THz to GHz'] = function () {
+  assert.strictEqual( convert(1).from('THz').to('GHz') , 1000);
+};
+
+tests['mHz to MHz'] = function () {
+  assert.strictEqual( convert(1).from('mHz').to('MHz') , 0.000000001);
+};
+
+
+
+module.exports = tests;

--- a/test/measures.js
+++ b/test/measures.js
@@ -4,7 +4,7 @@ var convert = require('../lib')
 
 tests['measures'] = function () {
   var actual = convert().measures()
-    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage', 'power', 'reactivePower', 'apparentPower', 'energy', 'reactiveEnergy', 'volumeFlowRate' ];
+    , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage', 'power', 'reactivePower', 'apparentPower', 'energy', 'reactiveEnergy', 'volumeFlowRate', 'frequency' ];
   assert.deepEqual(actual, expected);
 };
 

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -130,6 +130,12 @@ tests['reactive energy possibilities'] = function() {
   assert.deepEqual(actual.sort(), expected.sort())
 };
 
+tests['reactive energy possibilities'] = function() {
+  var actual = convert().possibilities('frequency')
+    , expected = [ 'Hz', 'mHz', 'kHz', 'MHz', 'GHz', 'THz', 'rpm', 'deg/s', 'rad/s'];
+  assert.deepEqual(actual.sort(), expected.sort())
+};
+
 tests['all possibilities'] = function () {
   var actual = convert().possibilities()
     // Please keep these sorted for maintainability
@@ -162,6 +168,7 @@ tests['all possibilities'] = function () {
       , 'cup'
       , 'cup/s'
       , 'd'
+      , 'deg/s'
       , 'dl'
       , 'dl/s'
       , 'ea'
@@ -184,6 +191,7 @@ tests['all possibilities'] = function () {
       , 'gal/min'
       , 'gal/s'
       , 'glas'
+      , 'GHz'
       , 'GVA'
       , 'GVAR'
       , 'GVARh'
@@ -192,6 +200,7 @@ tests['all possibilities'] = function () {
       , 'h'
       , 'hPa'
       , 'ha'
+      , 'Hz'
       , 'in'
       , 'in2'
       , 'in3'
@@ -217,6 +226,7 @@ tests['all possibilities'] = function () {
       , 'knot'
       , 'krm'
       , 'ksi'
+      , 'kHz'
       , 'kV'
       , 'kVA'
       , 'kVAR'
@@ -252,6 +262,8 @@ tests['all possibilities'] = function () {
       , 'ms'
       , 'msk'
       , 'mu'
+      , 'mHz'
+      , 'MHz'
       , 'mV'
       , 'mVA'
       , 'MVA'
@@ -276,9 +288,12 @@ tests['all possibilities'] = function () {
       , 'psi'
       , 'qt'
       , 'qt/s'
+      , 'rad/s'
+      , 'rpm'
       , 's'
       , 'Tbs'
       , 'Tbs/s'
+      , 'THz'
       , 'torr'
       , 'tsk'
       , 'tsp'


### PR DESCRIPTION
Adds the following measures of frequency: `Hz`, `mHz`, `kHz`, `MHz`, `GHz`, `THz`, `rpm`, `deg/s`, `rad/s`

* The SI standard unit: `Hz`
* Commonly used magnitudes: `kHz`, `MHz`, `GHz`, `THz`
* Other useful measurements:
    * Rotational frequency: `rpm`, `deg/s`, `rad/s`
* Other magnitudes for convenience: `mHz`