### PR TITLE
Add system conversion support to `.toBest()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 
 node_modules
 scratch

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ convert(1000).from('mm').toBest({ cutOffNumber: 10 })
 // 10 Meters (the smallest unit with a value equal to or above 10)
 ```
 
+You can also use `.toBest()` to have your values converted between systems
+```js
+convert(1).from('km').toBest({ system: "imperial" })
+// 1093.613... Yards
+
+convert(1.2427).from('mi').toBest({ system: "metric" })
+// 1.999... Km
+```
+
 You can get a list of the measurement types supported with `.measures`
 
 ```js

--- a/lib/index.js
+++ b/lib/index.js
@@ -129,20 +129,23 @@ Converter.prototype.toBest = function(options) {
 
   var options = Object.assign({
     exclude: [],
-    cutOffNumber: 1,
-  }, options)
+    cutOffNumber: 1
+  }, options);
 
   var best;
+
+  // if a system was given in options, honor that.
+  var system = options.system ? options.system : this.origin.system;
   /**
     Looks through every possibility for the 'best' available unit.
     i.e. Where the value has the fewest numbers before the decimal point,
-    but is still higher than 1.
+    but is still higher than or equal to `options.cutOffNumber`(default 1).
   */
   each(this.possibilities(), function(possibility) {
     var unit = this.describe(possibility);
     var isIncluded = options.exclude.indexOf(possibility) === -1;
 
-    if (isIncluded && unit.system === this.origin.system) {
+    if (isIncluded && unit.system === system) {
       var result = this.to(possibility);
       if (!best || (result >= options.cutOffNumber && result < best.val)) {
         best = {

--- a/test/best.js
+++ b/test/best.js
@@ -24,7 +24,7 @@ tests['excludes measurements'] = function () {
       };
 
   assert.deepEqual(actual, expected);
-}
+};
 
 tests['does not break when excluding from measurement'] = function () {
   var actual = convert(10).from('km').toBest({ exclude: ['km'] })
@@ -36,7 +36,7 @@ tests['does not break when excluding from measurement'] = function () {
       };
 
   assert.deepEqual(actual, expected);
-}
+};
 
 tests['if all measurements are excluded return from'] = function () {
   var actual = convert(10).from('km').toBest({ exclude: ['mm, cm, m, km'] })
@@ -48,7 +48,7 @@ tests['if all measurements are excluded return from'] = function () {
       };
 
   assert.deepEqual(actual, expected);
-}
+};
 
 tests['pre-cut off number'] = function () {
   var actual = convert(9000).from('mm').toBest({ cutOffNumber: 10 })
@@ -60,7 +60,7 @@ tests['pre-cut off number'] = function () {
       };
 
   assert.deepEqual(actual, expected);
-}
+};
 
 tests['post-cut off number'] = function () {
   var actual = convert(10000).from('mm').toBest({ cutOffNumber: 10 })
@@ -72,6 +72,54 @@ tests['post-cut off number'] = function () {
       };
 
   assert.deepEqual(actual, expected);
-}
+};
+
+tests['km to yard'] = function () {
+    var actual = convert(1).from('km').toBest({ system: "imperial" })
+        , expected = {
+        val: 1093.6133333333335
+        , unit: 'yd'
+        , singular: 'Yard'
+        , plural: 'Yards'
+    };
+
+    assert.deepEqual(actual, expected);
+};
+
+tests['km to mile'] = function () {
+    var actual = convert(2).from('km').toBest({ system: "imperial" })
+        , expected = {
+        val: 1.2427424242424243
+        , unit: "mi"
+        , singular: "Mile"
+        , plural: "Miles"
+    };
+
+    assert.deepEqual(actual, expected);
+};
+
+tests['yard to km'] = function () {
+    var actual = convert(1093.6133333333335).from('yd').toBest({ system: "metric" })
+        , expected = {
+        val: 1
+        , unit: "km"
+        , singular: "Kilometer"
+        , plural: "Kilometers"
+    };
+
+    assert.deepEqual(actual, expected);
+};
+
+tests['mile to km'] = function () {
+    var actual = convert(1.2427424242424243).from('mi').toBest({ system: "metric" })
+        , expected = {
+        val: 2
+        , unit: "km"
+        , singular: "Kilometer"
+        , plural: "Kilometers"
+    };
+
+    assert.deepEqual(actual, expected);
+};
 
 module.exports = tests;


### PR DESCRIPTION
It's now possible to give `.toBest()` and option `system`.

This is very handy when you are not sure what is the
equivalent to your current value in another system.

Duplicate for earlier pr https://github.com/ben-ng/convert-units/pull/31 it seems, sorry was blind, close if so desire.