### PR TITLE
Fix errors in the `toBest()` conversion examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ convert(12000).from('mm').toBest({ exclude: ['m'] })
 // 1200 Centimeters (the smallest unit excluding meters)
 
 convert(900).from('mm').toBest({ cutOffNumber: 10 });
-// 900 Centimeters (the smallest unit with a value equal to or above 10)
+// 90 Centimeters (the smallest unit with a value equal to or above 10)
 
 convert(1000).from('mm').toBest({ cutOffNumber: 10 })
-// 10 Meters (the smallest unit with a value equal to or above 10)
+// 100 Centimeters (the smallest unit with a value equal to or above 10)
 ```
 
 You can get a list of the measurement types supported with `.measures`


### PR DESCRIPTION
The comments below each `convert()` example are meant to demonstrate the library's result, but a few of the comments listen an incorrect value or unit. Ran each of the examples in this code block and adjusted the comments based on the library's result.