### PR TITLE
Correct singular and plural names of cm2

### DIFF
--- a/lib/definitions/area.js
+++ b/lib/definitions/area.js
@@ -11,8 +11,8 @@ metric = {
   }
 , cm2: {
     name: {
-      singular: 'Centimeter'
-    , plural: 'Centimeters'
+      singular: 'Square Centimeter'
+    , plural: 'Square Centimeters'
     }
   , to_anchor: 1/10000
   }


### PR DESCRIPTION
I notice the singular and plural of square centimenters are incorrect.