### PR TITLE
Added a new unit - "Horsepower, Mechanical (Imperial)" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Supported Units
 * kA
 
 ### Power
+* hp-i
 * W
 * mW
 * kW

--- a/lib/definitions/power.js
+++ b/lib/definitions/power.js
@@ -40,7 +40,7 @@ metric = {
 };
 
 imperial = {
-  'hp(i)': {
+  'hp-i': {
     name: {
       singular: 'Horsepower, Mechanical (Imperial)'
     , plural: 'Horsepower, Mechanical (Imperial)'
@@ -58,7 +58,7 @@ module.exports = {
     , ratio: 745.6998715823 
     }
   , imperial: {
-      unit: 'hp(i)'
+      unit: 'hp-i'
     , ratio: 1/745.6998715823 
     }
   }

--- a/lib/definitions/power.js
+++ b/lib/definitions/power.js
@@ -1,6 +1,7 @@
-var power;
+var metric
+  , imperial;
 
-power = {
+metric = {
   W: {
     name: {
       singular: 'Watt'
@@ -38,12 +39,27 @@ power = {
   }
 };
 
+imperial = {
+  'hp(i)': {
+    name: {
+      singular: 'Horsepower, Mechanical (Imperial)'
+    , plural: 'Horsepower, Mechanical (Imperial)'
+    }
+  , to_anchor: 1
+  }
+};
+
 module.exports = {
-  metric: power
+  metric: metric
+, imperial: imperial
 , _anchors: {
     metric: {
       unit: 'W'
-    , ratio: 1
+    , ratio: 745.6998715823 
+    }
+  , imperial: {
+      unit: 'hp(i)'
+    , ratio: 1/745.6998715823 
     }
   }
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -15,7 +15,7 @@ declare module "convert-units" {
     type uPartsPer = "ppm" | "ppb" | "ppt" | "ppq"; // Parts-Per
     type uVoltage = "V" | "mV" | "kV"; // Voltage
     type uCurrent = "A" | "mA" | "kA"; // Current
-    type uPower = "W" | "mW" | "kM" | "MW" | "GW"; // Power
+    type uPower = "W" | "mW" | "kM" | "MW" | "GW" | "hp(i)"; // Power
     type uApparentPower = "VA" | "mVA" | "kVA" | "MVA" | "GVA"; // Apparent Power
     type uReactivePower = "VAR" | "mVAR" | "kVAR" | "MVAR" | "GVAR"; // Reactive Power
     type uEnergy = "Wh" | "mWh" | "kWh" | "MWh" | "GWh" | "J" | "kJ"; // Energy

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -15,7 +15,7 @@ declare module "convert-units" {
     type uPartsPer = "ppm" | "ppb" | "ppt" | "ppq"; // Parts-Per
     type uVoltage = "V" | "mV" | "kV"; // Voltage
     type uCurrent = "A" | "mA" | "kA"; // Current
-    type uPower = "W" | "mW" | "kM" | "MW" | "GW";
+    type uPower = "W" | "mW" | "kM" | "MW" | "GW"; // Power
     type uApparentPower = "VA" | "mVA" | "kVA" | "MVA" | "GVA"; // Apparent Power
     type uReactivePower = "VAR" | "mVAR" | "kVAR" | "MVAR" | "GVAR"; // Reactive Power
     type uEnergy = "Wh" | "mWh" | "kWh" | "MWh" | "GWh" | "J" | "kJ"; // Energy

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -108,7 +108,7 @@ tests['voltage possibilities'] = function() {
 
 tests['power possibilities'] = function() {
   var actual = convert().possibilities('power')
-    , expected = [ 'W', 'mW', 'kW', 'MW', 'GW'];
+    , expected = [ 'W', 'mW', 'kW', 'MW', 'GW', 'hp-i'];
   assert.deepEqual(actual.sort(), expected.sort());
 };
 
@@ -243,6 +243,7 @@ tests['all possibilities'] = function () {
       , 'GW'
       , 'GWh'
       , 'h'
+      , 'hp-i'
       , 'hPa'
       , 'ha'
       , 'Hz'

--- a/test/power.js
+++ b/test/power.js
@@ -1,6 +1,8 @@
 var convert = require('../lib')
   , assert = require('assert')
-  , tests = {};
+  , tests = {}
+  , ACCURACY = 1/1000
+  , percentError = require('../lib/percentError');
 
 tests['W to W'] = function () {
   assert.strictEqual( convert(1).from('W').to('W') , 1);
@@ -61,5 +63,47 @@ tests['mW to W'] = function () {
 tests['kW to W'] = function () {
   assert.strictEqual( convert(1).from('kW').to('W'), 1000);
 }
+
+
+tests['hp-i to hp-i'] = function () {
+  assert.strictEqual( convert(1).from('hp-i').to('hp-i'), 1);
+}
+
+
+// When converting between systems, expect < 0.1% error
+tests['W to hp-i'] = function () {
+  var expected = 745.6998715823 
+    , actual = convert(1).from('W').to('hp-i');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
+};
+
+tests['mW to hp-i'] = function () {
+  var expected = 0.7456998715832 
+    , actual = convert(1).from('mW').to('hp-i');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
+};
+
+tests['kW to hp-i'] = function () {
+  var expected = 745699.8715823
+    , actual = convert(1).from('kW').to('hp-i');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
+};
+
+tests['MW to hp-i'] = function () {
+  var expected = 745699871.5823
+    , actual = convert(1).from('MW').to('hp-i');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
+};
+
+tests['GW to hp-i'] = function () {
+  var expected = 745699871582.3
+    , actual = convert(1).from('GW').to('hp-i');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
+};
 
 module.exports = tests;

--- a/test/power.js
+++ b/test/power.js
@@ -106,4 +106,35 @@ tests['GW to hp-i'] = function () {
     , 'Expected: ' + expected +', Actual: ' + actual);
 };
 
+
+
+
+tests['hp-i to W'] = function () {
+  var expected = 0.00134102208959497437975129597236
+    , actual = convert(1).from('hp-i').to('W');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
+};
+
+tests['hp-i to kW'] = function () {
+  var expected = 1.34102208959497437975129597236e-6
+    , actual = convert(1).from('hp-i').to('kW');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
+};
+
+tests['hp-i to MW'] = function () {
+  var expected = 1.34102208959497437975129597236e-9
+    , actual = convert(1).from('hp-i').to('MW');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
+};
+
+tests['hp-i to GW'] = function () {
+  var expected = 1.3410220895949743797512959723589e-12
+    , actual = convert(1).from('hp-i').to('GW');
+  assert.ok( percentError(expected, actual) < ACCURACY
+    , 'Expected: ' + expected +', Actual: ' + actual);
+};
+
 module.exports = tests;


### PR DESCRIPTION
I know my addition is small, but my plan is to add a lot more units in the future if I can get this one approved.

I used multiple unit conversion websites to cross-check the conversion ratio that I used.

Let me know if you think a different name would be better than 'hp-i'.  
The reason for the trailing '-i' is that there is also Metric Horsepower (which, again, I would like to add in the future).

I was considering naming it 'hp(i)', but I noticed that US feet is named 'ft-us', so I went with 'hp-i' instead for conformity.

Feel free to critique my proposed change as you see fit.